### PR TITLE
look up full path of icon on start up

### DIFF
--- a/notifymuch/notification.py
+++ b/notifymuch/notification.py
@@ -1,6 +1,6 @@
 import shlex
 import subprocess
-from gi.repository import Notify, Gio
+from gi.repository import Notify, Gio, Gtk
 from notifymuch import config
 from notifymuch.messages import Messages
 
@@ -10,6 +10,7 @@ __all__ = ["show_notification"]
 
 class NotifymuchNotification(Gio.Application):
     ICON = 'mail-unread-symbolic'
+    ICON_SIZE = 64
 
     def __init__(self):
         Gio.Application.__init__(
@@ -21,6 +22,11 @@ class NotifymuchNotification(Gio.Application):
     def on_startup(self, data):
         config.load()
         Notify.init('notifymuch')
+
+        icon = Gtk.IconTheme.get_default ().lookup_icon (self.ICON,
+                self.ICON_SIZE, 0)
+        self.ICON = icon.get_filename ()
+
         self.notification = Notify.Notification.new('', '', self.ICON)
         self.notification.set_category('email.arrived')
         if config.get("mail_client"):


### PR DESCRIPTION
Using the icon-name doesn't always work, looking up the full path to the file seems to be more robust.
