### PR TITLE
exist_ok behavior is inconsistent in os.makedirs, remove that.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,13 @@ seen' and not shown again for two days (configurable).
 Installation and usage
 ----------------------
 
-The program requires Python 3, setuptools, pygobject and notmuch.
-It can be installed together with its dependencies using::
+The program requires Python 3, setuptools, pygobject and notmuch. Notmuch isn't
+available on PyPI anymore, so you need to install it separately using either
+your system package manager(available for Ubuntu, Debian, Fedora and other major
+distributions) or directly from sources. It is generally called
+`python3-notmuch`.
+
+It can be installed together with rest of its dependencies using::
 
     pip install .
 

--- a/notifymuch/config.py
+++ b/notifymuch/config.py
@@ -23,7 +23,11 @@ def load():
     global CONFIG
     CONFIG['notifymuch'] = DEFAULT_CONFIG
     if not CONFIG.read(CONFIG_FILE):
-        os.makedirs(CONFIG_DIR, exist_ok=True)
+        try:
+            os.makedirs(CONFIG_DIR)
+        except OSError as e:
+            if e.errno == 17:
+                print('The directory CONFIG_DIR exists')
         with open(CONFIG_FILE, "w") as f:
             CONFIG.write(f)
 

--- a/notifymuch/messages.py
+++ b/notifymuch/messages.py
@@ -15,7 +15,11 @@ LAST_SEEN_FILE = os.path.join(CACHE_DIR, 'last_seen')
 
 
 def exclude_recently_seen(messages):
-    os.makedirs(CACHE_DIR, exist_ok=True)
+    try:
+        os.makedirs(CACHE_DIR)
+    except OSError as e:
+        if e.errno == 17:
+            print('The directory CACHE_DIR exists.')
     recency_interval = int(config.get('recency_interval_hours')) * 60 * 60
     with shelve.open(LAST_SEEN_FILE) as last_seen:
         now = time.time()
@@ -38,7 +42,7 @@ def filter_tags(ts):
 
 def ellipsize(text, length=80):
     if len(text) > length:
-        return text[:length - 1] + '…'
+        return text[:length - 1] + '...'
     else:
         return text
 


### PR DESCRIPTION
Python's os.makedirs' parameter exist_ok fails even if the mode is different as
expected by the program. Use a simple try except to find out if the directory
already exists and supress the error raised.